### PR TITLE
Make it work for new install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
 sonotoria
-numpy
-opencv-python
-Pillow

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,15 +1,22 @@
-from modules import script_callbacks
+import os
+import gradio as gr
+from modules import script_callbacks, shared, scripts
+
+default_sc_loader_config_path = os.path.join(scripts.current_basedir, 'base_configs')
+shared.options_templates.update(shared.options_section(('sc_loader', 'Scenario loader'), {
+    "sc_loader_config_path_custom": shared.OptionInfo("", "Custom path to configuration", gr.Textbox, {'interactive': True}).info(f'Defaults to "{default_sc_loader_config_path}"'),
+}))
+shared.opts.sc_loader_config_path = shared.opts.sc_loader_config_path_custom if shared.opts.sc_loader_config_path_custom else default_sc_loader_config_path
 
 from sc_loader.ui import ScLoaderTab, PromptCreatorTab, SettingsTab, ToolsTab, DBEditTab
 
-
 scl_tab = ScLoaderTab()
 pc_tag = PromptCreatorTab()
-settings = SettingsTab()
+# settings = SettingsTab()
 tools = ToolsTab()
 db_edit = DBEditTab()
 
-script_callbacks.on_ui_settings(settings.build)
+# script_callbacks.on_ui_settings(settings.build)
 script_callbacks.on_ui_tabs(scl_tab.build)
 script_callbacks.on_ui_tabs(pc_tag.build)
 script_callbacks.on_ui_tabs(tools.build)


### PR DESCRIPTION
### Remove unnecessary requirements
`numpy` `opencv-python` `Pillow` are already installed by webui
also due to also `Pillow` package name is `PIL` and `opencv-python` package name is `cv2` the `is_installed()` test will always return false
this causes `sc_loader requirement: ` message spamming

---
### Fix sc_loader_config_path

since you explicitly specified a static default path 
it will not work if one uses `--data-dir`

also probably during testing you already have `sc_loader_config_path` saved in to your `config.json`
but since a new user will not have this value already in there
the code will error with on a new install
```shell
AttributeError: 'Options' object has no attribute 'sc_loader_config_path'
```
this prevents it from working on a new install

the chenges initialize the setting at the earliest stage so that new uses will not have this issue
I made it so that if the value is `blank` then it will default to the correct path even when `--data-dir` is used

I didn't do code cleanup
only comment out `settings = SettingsTab()` and `script_callbacks.on_ui_settings(settings.build)`

Note
I reuse the same object `shared.opts.sc_loader_config_path` for storing the path.
normally I wouldn't do this but because I don't want to make too many changes to the code base I just use convenient
> you could also just directly use the generated default value as the value for the setting (without the blank then use default), but this would mean if one move there webui install thing might break

---
### other not fixed
you seem to forgot to input some values in `./base_configs/_db/prompts/negatives/misc.yaml`
```shell
[ERROR] Expected dict or list at ../data\extensions\sd-webui-sc-loader\base_configs/_db/prompts/negatives/misc.yaml, value ignored...
```
I would bet that people would open issues asking why ther are getting this message
~~(worse they likely would posting on a1111/webui issue tab causing confusion)~~

---
### minor warning
I think allowing users to customize the path is totally fine but be careful as 
if the instance is shared to be public this can possible be exploited to getting access to the entire computer files
as this use case seems to limit the access to certain type of file types under dir a specific structure so it should be fine